### PR TITLE
Add polyserial correlation function

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Sanchez"
+  given-names: "Ryan"
+  orcid: "https://orcid.org/0000-0003-0931-5335"
+title: "RyStats: Statistical Analysis"
+version: 0.5.0
+date-released: 2021-10-29
+url: "https://github.com/eribean/RyStats"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 # RyStats
 
-A collection of statistical packages writtten in python.
+A collection of statistical functions written in python. Many of these functions can be accessed
+without downloading any software at [GoFactr](https://gofactr.com)
 
 ## Factor Analysis
 
@@ -17,22 +18,39 @@ Several factor analysis routines are implemented including:
 2. Principal Axis Factoring
 3. Maximum Likelihood
 4. Minimum Rank
+5. Minimum Residual
 
-### Rotation
+## Rotation
 
 1. Orthogonal / Oblique
 2. Procrustes
 
-### Dimensionality Assessment
+## Dimensionality Assessment
 
  1. Parallel Analysis
  2. MAP (Minimum Average Partial)
 
-### Miscellaneous
+## Correlations
 
 1. Polychoric Correlations
+2. Polyserial Correlations
+3. Biserial Correlations
 
-# Plotting Tools
+## Inferential Analysis
+
+1. Linear Regression
+2. Logistic Regression
+3. One/Two-way Anova
+4. T-Tests
+5. Mediation
+
+## Survey Utilities
+
+1. Reverse Scoring
+2. Cronbach's Alpha
+3. McDonald's Omega
+
+## Plotting Tools
 
 Plotting Tools require Bokeh and are made to be used within a Jupyter Notebook
 

--- a/inferential/correlation.py
+++ b/inferential/correlation.py
@@ -1,9 +1,10 @@
 import numpy as np
 
 from scipy import stats as sp
+from scipy.optimize import fminbound
 
 
-__all__ =  ['pearsons_correlation']
+__all__ =  ['pearsons_correlation', 'polyserial_correlation']
 
 
 def pearsons_correlation(raw_data):
@@ -26,8 +27,77 @@ def pearsons_correlation(raw_data):
     t_critical = sp.t.isf([.025, .005, 0.0005] , deg_of_freedom)
     r_critical = np.sqrt(t_critical**2 / (t_critical**2 + deg_of_freedom))
 
-    return {'Correlation': correlation, 
-            'R critical': {'.05': r_critical[0],
-                           '.01': r_critical[1],
-                           '.001': r_critical[2]},
-           }   
+    return {
+        'Correlation': correlation, 
+        'R critical': {'.05': r_critical[0],
+                       '.01': r_critical[1],
+                       '.001': r_critical[2]},
+    }   
+
+
+def polyserial_correlation(continuous, ordinal):
+    """Computes the polyserial correlation.
+    
+    Estimates the correlation value based on a bivariate
+    normal distribution. If the ordinal input is dichotomous, 
+    then the biserial correlation is returned.
+    
+    Args:
+        continuous: Continuous Measurement
+        ordinal: Ordinal Measurement
+        
+    Returns:
+        polyserial_correlation: correlation value
+        
+    Notes:
+        User must handle missing data
+    """
+    # Get the number of ordinal values
+    values, counts = np.unique(ordinal, return_counts=True)
+    
+    # Compute the thresholds (tau's)
+    thresholds = sp.norm.isf(1 - counts.cumsum() / counts.sum())[:-1]
+    
+    # Standardize the continuous variable
+    standardized_continuous = ((continuous - continuous.mean())
+                               / continuous.std(ddof=1))
+
+    def _min_func(correlation):
+        denominator = np.sqrt(1 - correlation * correlation)
+        k = standardized_continuous * correlation
+        log_likelihood = 0
+        
+        for ndx, value in enumerate(values):
+            mask = ordinal == value
+            
+            if ndx == 0:
+                numerator = thresholds[ndx] - k[mask]
+                probabilty = sp.norm.cdf(numerator / denominator)
+                
+            elif ndx == (values.size -1):
+                numerator = thresholds[ndx-1] - k[mask]
+                probabilty = (1 - sp.norm.cdf(numerator / denominator))
+                
+            else:
+                numerator1 = thresholds[ndx] - k[mask]
+                numerator2 = thresholds[ndx-1] - k[mask]
+                probabilty = (sp.norm.cdf(numerator1 / denominator)
+                              - sp.norm.cdf(numerator2 / denominator))
+        
+            log_likelihood -= np.log(probabilty).sum()
+        
+        return log_likelihood
+        
+    rho = fminbound(_min_func, -.99, .99)
+
+    # Likelihood ratio test
+    log_likelihood_rho = _min_func(rho)
+    log_likelihood_zero = _min_func(0.0)
+    likelihood_ratio = -2 * (log_likelihood_rho - log_likelihood_zero)
+    p_value = sp.chi2.sf(likelihood_ratio, 1)
+    
+    return {
+        'Correlation': rho,
+        'Likelihood Ratio': likelihood_ratio,
+        'p-value': p_value
+    }

--- a/inferential/correlation.py
+++ b/inferential/correlation.py
@@ -47,7 +47,7 @@ def polyserial_correlation(continuous, ordinal):
         ordinal: Ordinal Measurement
         
     Returns:
-        polyserial_correlation: correlation value
+        dict: Dictionary of correlation,likelilhood ratio test (chi-squared), and p value
         
     Notes:
         User must handle missing data

--- a/inferential/test/test_correlation.py
+++ b/inferential/test/test_correlation.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from RyStats.inferential import pearsons_correlation
+from RyStats.inferential import pearsons_correlation, polyserial_correlation
 
 
 class TestCorrelation(unittest.TestCase):
@@ -25,6 +25,46 @@ class TestCorrelation(unittest.TestCase):
                             - n_items) / (n_items * (n_items - 1))
 
         self.assertAlmostEqual(significant_data, .05, delta=0.01)
+
+
+class TestPolyserialCorrelation(unittest.TestCase):
+    """Polyserial Correlation Test Fixture."""
+
+    def test_polyserial_correlation(self):
+        """Testing polyserial corelation function."""
+        rng = np.random.default_rng(425365645347626485721532938464553254)
+        
+        rho = -0.6
+        thresholds = [-.2, 0., .8]
+        continuous = rng.multivariate_normal([0, 0], [[1, rho], 
+                                                       [rho, 1]], size=10000)
+        ordinal = np.digitize(continuous[:, 1], thresholds)
+
+        result = polyserial_correlation(continuous[:, 0], ordinal)
+        point_polyserial = np.corrcoef(continuous[:, 0], ordinal)[0, 1]
+
+        self.assertAlmostEqual(result, rho, delta=.01)
+        self.assertLess(np.abs(result - rho),
+                        np.abs(point_polyserial - rho))
+
+    def test_biserial_correlation(self):
+        """Testing biserial correlation."""
+        # The polyserial function should include binary
+        # inputs
+        rng = np.random.default_rng(7921354169283445716651382455716656333145)
+        
+        rho = 0.45
+        thresholds = [.3]
+        continuous = rng.multivariate_normal([0, 0], [[1, rho], 
+                                                       [rho, 1]], size=10000)
+        ordinal = np.digitize(continuous[:, 1], thresholds)
+
+        result = polyserial_correlation(continuous[:, 0], ordinal)
+        point_polyserial = np.corrcoef(continuous[:, 0], ordinal)[0, 1]
+
+        self.assertAlmostEqual(result, rho, delta=.015)
+        self.assertLess(np.abs(result - rho),
+                        np.abs(point_polyserial - rho))               
 
 if __name__ == "__main__":
     unittest.main()

--- a/inferential/test/test_correlation.py
+++ b/inferential/test/test_correlation.py
@@ -40,7 +40,7 @@ class TestPolyserialCorrelation(unittest.TestCase):
                                                        [rho, 1]], size=10000)
         ordinal = np.digitize(continuous[:, 1], thresholds)
 
-        result = polyserial_correlation(continuous[:, 0], ordinal)
+        result = polyserial_correlation(continuous[:, 0], ordinal)['Correlation']
         point_polyserial = np.corrcoef(continuous[:, 0], ordinal)[0, 1]
 
         self.assertAlmostEqual(result, rho, delta=.01)
@@ -59,7 +59,7 @@ class TestPolyserialCorrelation(unittest.TestCase):
                                                        [rho, 1]], size=10000)
         ordinal = np.digitize(continuous[:, 1], thresholds)
 
-        result = polyserial_correlation(continuous[:, 0], ordinal)
+        result = polyserial_correlation(continuous[:, 0], ordinal)['Correlation']
         point_polyserial = np.corrcoef(continuous[:, 0], ordinal)[0, 1]
 
         self.assertAlmostEqual(result, rho, delta=.015)


### PR DESCRIPTION
The following function was added 

```python
polyserial_correlation(continuous, ordinal)
```

It returns the found correlation and likelihood ratio test which is approximately distributed as a chi-square distribtion.